### PR TITLE
Add Markdown export to WAPI

### DIFF
--- a/src/capi.zig
+++ b/src/capi.zig
@@ -192,6 +192,13 @@ export fn zpdf_extract_all_markdown(handle: ?*ZpdfDocument, out_len: *usize) ?[*
     if (handle) |h| {
         const doc: *zpdf.Document = @ptrCast(@alignCast(h));
         const result = doc.extractAllMarkdown(c_allocator) catch return null;
+
+        // extractAllMarkdown returns an allocated slice; treat zero-length as "no data"
+        if (result.len == 0) {
+            out_len.* = 0;
+            return null;
+        }
+
         out_len.* = result.len;
         return result.ptr;
     }

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -195,6 +195,7 @@ export fn zpdf_extract_all_markdown(handle: ?*ZpdfDocument, out_len: *usize) ?[*
 
         // extractAllMarkdown returns an allocated slice; treat zero-length as "no data"
         if (result.len == 0) {
+            c_allocator.free(result);
             out_len.* = 0;
             return null;
         }

--- a/src/wapi.zig
+++ b/src/wapi.zig
@@ -128,6 +128,13 @@ export fn zpdf_extract_all_markdown(handle: i32, out_len: *usize) ?[*]u8 {
 
     if (documents[idx]) |doc| {
         const result = doc.extractAllMarkdown(wasm_allocator) catch return null;
+
+        // Handle empty buffer - toOwnedSlice returns undefined ptr for empty slice
+        if (result.len == 0) {
+            out_len.* = 0;
+            return null;
+        }
+
         out_len.* = result.len;
         return result.ptr;
     }

--- a/src/wapi.zig
+++ b/src/wapi.zig
@@ -129,7 +129,7 @@ export fn zpdf_extract_all_markdown(handle: i32, out_len: *usize) ?[*]u8 {
     if (documents[idx]) |doc| {
         const result = doc.extractAllMarkdown(wasm_allocator) catch return null;
 
-        // Handle empty buffer - toOwnedSlice returns undefined ptr for empty slice
+        // extractAllMarkdown returns an allocated slice; treat zero-length as "no data"
         if (result.len == 0) {
             out_len.* = 0;
             return null;

--- a/src/wapi.zig
+++ b/src/wapi.zig
@@ -119,6 +119,21 @@ export fn zpdf_extract_all(handle: i32, out_len: *usize) ?[*]u8 {
     return null;
 }
 
+/// Extract text from all pages as Markdown with semantic formatting
+/// Returns pointer to Markdown text buffer, sets out_len to buffer length
+/// Caller must free with wasm_free
+export fn zpdf_extract_all_markdown(handle: i32, out_len: *usize) ?[*]u8 {
+    if (handle < 0 or handle >= MAX_DOCUMENTS) return null;
+    const idx: usize = @intCast(handle);
+
+    if (documents[idx]) |doc| {
+        const result = doc.extractAllMarkdown(wasm_allocator) catch return null;
+        out_len.* = result.len;
+        return result.ptr;
+    }
+    return null;
+}
+
 /// Get page dimensions
 /// Returns 0 on success, -1 on error
 export fn zpdf_get_page_info(handle: i32, page_num: i32, width: *f64, height: *f64, rotation: *i32) i32 {


### PR DESCRIPTION
Currently WebAssembly build does not support Markdown export. I made this function available in WAPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Markdown export option to extract full document text as Markdown.

* **Bug Fixes**
  * Empty extraction results are now treated as "no data" — empty outputs return no content and length is set to 0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->